### PR TITLE
Set max-width to page branding for correct content display

### DIFF
--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -374,8 +374,12 @@ a:visited {
 .page-branding {
   display: flex;
   flex-direction: column;
-  width: 317px;
+  max-width: 100%;
   justify-content: space-between;
+
+  @media (width >= 500px) {
+    width: 317px;
+  }
 }
 
 .logo-container--footer {


### PR DESCRIPTION
Set max width to page branding in footer section so that page tagline stays in parent element.